### PR TITLE
Improve child process test end handling

### DIFF
--- a/server/node_modules/pstree.remy/tests/index.test.js
+++ b/server/node_modules/pstree.remy/tests/index.test.js
@@ -26,7 +26,8 @@ function testTree(t, runCallCount) {
   const sub = spawn('node', [`${__dirname}/fixtures/index.js`, runCallCount], {
     stdio: 'pipe',
   });
-  setTimeout(() => {
+
+  const handle = () => {
     const pid = sub.pid;
 
     pstree(pid, (error, pids) => {
@@ -38,9 +39,18 @@ function testTree(t, runCallCount) {
       // are looking for two processes.
       // Important: IDKW but MacOS seems to skip the `sh` process. no idea.
       t.equal(pids.length, runCallCount * 2);
-      t.end();
+
+      sub.once('exit', () => {
+        t.end();
+      });
     });
-  }, 1000);
+  };
+
+  if (sub.stdout) {
+    sub.stdout.once('data', handle);
+  } else {
+    handle();
+  }
 }
 
 test('can read full process tree', (t) => {


### PR DESCRIPTION
## Summary
- watch for `exit` when running child process tests

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6852d8fdb374832c99ac9e812f1567ab